### PR TITLE
Accept both name and username

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/Project.js
+++ b/packages/node_modules/@node-red/runtime/lib/storage/localfilesystem/projects/Project.js
@@ -35,8 +35,13 @@ var authCache = require("./git/authCache");
 // TODO: DRY - red/api/editor/sshkeys !
 function getSSHKeyUsername(userObj) {
     var username = '__default';
-    if ( userObj && userObj.name ) {
-        username = userObj.name;
+    if ( userObj ) {
+        if ( userObj.name ) {
+            username = userObj.name;
+        }
+        else if ( userObj.username ) {
+            username = userObj.username;
+        }
     }
     return username;
 }


### PR DESCRIPTION
Login seems to generally expect username to be set (eg when using auth0's default passport module, its failure to set username meant login failed) but in this code NR only checks for name. 

See here for mention of username:

https://nodered.org/docs/security

I think it would be safe to fallback to also accepting username, given other parts of NR seem to expect that to be set anyway. It seems a bit buggy to have to define both to satisfy different bits of code, but perhaps there are reasons for that I don't understand...

<!--
## Before you hit that Submit button....

Please read our [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
before submitting a pull-request.

## Types of changes

What types of changes does your code introduce?
Put an `x` in the boxes that apply
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

<!--
If you want to raise a pull-request with a new feature, or a refactoring
of existing code, it **may well get rejected** if it hasn't been discussed on
the [forum](https://discourse.nodered.org) or
[slack team](https://nodered.org/slack) first.

-->

## Proposed changes

<!-- Describe the nature of this change. What problem does it address? -->

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [x] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
